### PR TITLE
Add JPXImage.ToMemoryStream() method and make sure stream is disposed when calling JPXImage.ToArray()

### DIFF
--- a/JPXImage.cs
+++ b/JPXImage.cs
@@ -427,9 +427,22 @@ namespace OpenJpeg
         /// <remarks>Should perhaps leave out the alpha channels</remarks>
         public byte[] ToArray()
         {
+            using (var ms = ToMemoryStream())
+            {
+                return ms.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Returns the raw image data as a stream of bytes. Note
+        /// that this method will rezise channels that don't fit.
+        /// </summary>
+        /// <remarks>Should perhaps leave out the alpha channels</remarks>
+        public MemoryStream ToMemoryStream()
+        {
             //Determine resolution.
             uint w = x1 - x0, h = y1 - y0;
-            
+
             //Resize channels if needed
             var cc = new int[comps.Length][];
             for (int c = 0; c < comps.Length; c++)
@@ -457,7 +470,7 @@ namespace OpenJpeg
                 bio.Flush();
             }
 
-            return ms.ToArray();
+            return ms;
         }
 
         /// <summary>


### PR DESCRIPTION
Thank you for your outstanding work in porting OpenJPEG to C#! This project fills a significant gap, and I’ve been searching for a managed solution like this for some time.

This PR introduces a `ToMemoryStream()` method to the `JPXImage` class.

For background, the library is going to be very useful for me as part of [PdfPig](https://github.com/UglyToad/PdfPig). So far for JPX decoding, I was using bindings to the native library via https://github.com/BobLd/UglyToad.PdfPig.Filters.Jpx.OpenJpegDotNet/tree/master. I'm going to release an alternative package based on your work.

Additionally, do you have plans to publish this library as a NuGet package? If you need any assistance with code cleanup or general maintenance, I’d be happy to contribute.

Thanks again for your efforts!